### PR TITLE
Add an option for Relative URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ jobs:
 - `chart`: Helm chart path. (default: `./`)
 - `forceRelease`: If set to `false` and the chart already exists, exit normally and do not trigger an error. (default: `true`).
 - `packageExtraArgs`: Helm [package](https://helm.sh/docs/helm/helm_package/) command extra arguments.
+- `relativeUrls`: Helm-s3 push option for creating URLs that are relative to the Index location. By default, URLs are the full path using `s3://` protocol. If you intend to serve your Helm repository via http(s), you should enable this option. (default: `false`)
 
 ## Build with
 

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
   packageExtraArgs:
     description: Helm package command extra arguments.
     required: false
+  relativeUrls:
+    description: Create the index with relative URLs. Useful for http(s) serving of helm repos
+    default: 'false'
+    required: true
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -29,3 +33,4 @@ runs:
     - ${{ inputs.chart }}
     - ${{ inputs.repo }}
     - ${{ inputs.forceRelease }}
+    - ${{ inputs.relativeUrls }}

--- a/index.js
+++ b/index.js
@@ -57,6 +57,11 @@ function push() {
     args.push('--ignore-if-exists');
   }
 
+  const relativeUrls = core.getInput('relativeUrls', { required: true }) == 'true';
+  if (relativeUrls) {
+    args.push('--relative');
+  }
+
   return args;
 }
 


### PR DESCRIPTION
The s3 plugin supports an option for creating the Index with [relative URLs](https://github.com/hypnoglow/helm-s3#relative-chart-urls)

I was surprised to find that when I attempted to use my helm repo from S3 (set up with CloudFront and https) that the charts didn't work because they were referencing an `s3://` protocol URL. Using the `reindex` command manually - with `--relative` made it functional.

Rather than have to run a reindex in my GitHub action as an additional step, I'd like to see this option added to the action. This PR should accomplish that, and leaves the default functionality as it is today.