### PR TITLE
Add helmS3Version input to specify Helm S3 plugin version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Build and release Helm packages on s3 repositories using Github Actions.
 Instructions on how to set up a S3 bucket as a helm chart repository: https://andrewlock.net/how-to-create-a-helm-chart-repository-using-amazon-s3/.
 
 ## Changelog
-
+- 0.3: Added an option to specify the `helm-s3` plugin version. Defaults to the latest GitHub release but allows users to override it.  
 - 0.2: Add an option for Relative URLs [Thanks to this PR](https://github.com/shellbear/helm-release-action/pull/4) [@aztechian](https://github.com/aztechian)
 - 0.1: Initial release
 
@@ -34,6 +34,7 @@ jobs:
         with:
           repo: s3://s3-bucket-example/
           chart: ./deployment/helm
+          helmS3Version: "0.16.2"  # Optional, specify Helm S3 plugin version
 ```
 
 ## Parameters
@@ -51,7 +52,7 @@ jobs:
 - `forceRelease`: If set to `false` and the chart already exists, exit normally and do not trigger an error. (default: `true`).
 - `packageExtraArgs`: Helm [package](https://helm.sh/docs/helm/helm_package/) command extra arguments.
 - `relativeUrls`: Helm-s3 push option for creating URLs that are relative to the Index location. By default, URLs are the full path using `s3://` protocol. If you intend to serve your Helm repository via http(s), you should enable this option. (default: `false`)
-
+`helmS3Version`: **(New in v0.3)** Specify the `helm-s3` plugin version to install. Defaults to the latest GitHub release.
 ## Build with
 
 - [helm-s3](https://github.com/hypnoglow/helm-s3.git)

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'Helm release'
-description: 'Build and release Helm packages on s3 repositories.'
+description: 'Build and release Helm packages on S3 repositories.'
 branding:
   icon: 'arrow-up-circle'
   color: 'blue'
@@ -8,23 +8,26 @@ inputs:
     description: Override Helm chart version.
     required: false
   chart:
-    description: The local Helm cart folder path.
+    description: The local Helm chart folder path.
     default: './'
     required: true
   repo:
     description: The S3 Helm repository bucket URL.
     required: true
   forceRelease:
-    description: Force and replace existing release if a release with the same version already exist.
+    description: Force and replace existing release if a release with the same version already exists.
     default: 'true'
     required: true
   packageExtraArgs:
     description: Helm package command extra arguments.
     required: false
   relativeUrls:
-    description: Create the index with relative URLs. Useful for http(s) serving of helm repos
+    description: Create the index with relative URLs. Useful for HTTP(S) serving of Helm repos.
     default: 'false'
     required: true
+  helmS3Version:
+    description: 'The version of the Helm S3 plugin to install. Defaults to the latest release from GitHub.'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -34,3 +37,4 @@ runs:
     - ${{ inputs.repo }}
     - ${{ inputs.forceRelease }}
     - ${{ inputs.relativeUrls }}
+    - ${{ inputs.helmS3Version }}  # Ensure it's passed to the script

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const core = require('@actions/core');
 const exec = require('@actions/exec');
 const path = require('path');
 const fs = require('fs');
+const { getLatestHelmS3Version } = require('./utils'); // Utility function for fetching latest release
 
 const HELM = 'helm';
 const REPO_ALIAS = 'repo';
@@ -9,16 +10,9 @@ const RELEASE_DIR = '.release/';
 
 // Returns argument required to register the S3 repository.
 function repo() {
-  const repo = core.getInput('repo', {
-    required: true,
-  });
+  const repo = core.getInput('repo', { required: true });
 
-  return [
-    'repo',
-    'add',
-    REPO_ALIAS,
-    repo,
-  ];
+  return ['repo', 'add', REPO_ALIAS, repo];
 }
 
 // Returns argument required to generate the chart package.
@@ -43,13 +37,8 @@ function package() {
 // Returns argument required to push the chart release to S3 repository.
 function push() {
   const releaseFile = path.join(RELEASE_DIR, fs.readdirSync(RELEASE_DIR)[0]);
-  const args = [
-    's3',
-    'push',
-    releaseFile,
-    REPO_ALIAS,
-  ];
-  
+  const args = ['s3', 'push', releaseFile, REPO_ALIAS];
+
   const forceRelease = core.getInput('forceRelease', { required: true }) === 'true';
   if (forceRelease) {
     args.push('--force');
@@ -57,7 +46,7 @@ function push() {
     args.push('--ignore-if-exists');
   }
 
-  const relativeUrls = core.getInput('relativeUrls', { required: true }) == 'true';
+  const relativeUrls = core.getInput('relativeUrls', { required: true }) === 'true';
   if (relativeUrls) {
     args.push('--relative');
   }
@@ -66,21 +55,33 @@ function push() {
 }
 
 // Returns argument required to install helm-s3 and helm-pack plugins.
-function installPlugins() {
-  const plugins = [
-    'https://github.com/hypnoglow/helm-s3.git',
-    'https://github.com/thynquest/helm-pack.git',
-  ];
+async function installPlugins() {
+  try {
+    let helmS3Version = core.getInput('helmS3Version'); // Optional input
+    if (!helmS3Version) {
+      helmS3Version = await getLatestHelmS3Version(); // Fetch latest if not provided
+    }
 
-  return Promise.all(plugins.map(plugin => exec.exec(HELM, ['plugin', 'install', plugin])));
+    const plugins = [
+      `https://github.com/hypnoglow/helm-s3.git@${helmS3Version}`,
+      'https://github.com/thynquest/helm-pack.git',
+    ];
+
+    for (const plugin of plugins) {
+      await exec.exec(HELM, ['plugin', 'install', plugin]);
+    }
+  } catch (err) {
+    core.error(`Failed to install plugins: ${err.message}`);
+    throw err;
+  }
 }
 
 async function main() {
   try {
     await installPlugins();
-    await exec.exec(HELM, repo()),
-    await exec.exec(HELM, package()),
-    await exec.exec(HELM, push())
+    await exec.exec(HELM, repo());
+    await exec.exec(HELM, package());
+    await exec.exec(HELM, push());
   } catch (err) {
     core.error(err);
     core.setFailed(err.message);

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function package() {
     RELEASE_DIR,
     ...core.getInput('packageExtraArgs').split(/\s+/),
   ];
-  
+
   const version = core.getInput('version');
   if (version) {
     args.push('--version', version);
@@ -62,14 +62,11 @@ async function installPlugins() {
       helmS3Version = await getLatestHelmS3Version(); // Fetch latest if not provided
     }
 
-    const plugins = [
-      `https://github.com/hypnoglow/helm-s3.git@${helmS3Version}`,
-      'https://github.com/thynquest/helm-pack.git',
-    ];
+    // Install helm-s3 with --version flag
+    await exec.exec(HELM, ['plugin', 'install', 'https://github.com/hypnoglow/helm-s3.git', '--version', helmS3Version]);
 
-    for (const plugin of plugins) {
-      await exec.exec(HELM, ['plugin', 'install', plugin]);
-    }
+    // Install helm-pack
+    await exec.exec(HELM, ['plugin', 'install', 'https://github.com/thynquest/helm-pack.git']);
   } catch (err) {
     core.error(`Failed to install plugins: ${err.message}`);
     throw err;

--- a/utils.js
+++ b/utils.js
@@ -1,24 +1,14 @@
-const { exec } = require('@actions/exec');
-
 async function getLatestHelmS3Version() {
-  let output = '';
-  await exec('curl', [
-    '-s',
-    'https://api.github.com/repos/hypnoglow/helm-s3/releases/latest'
-  ], {
-    listeners: {
-      stdout: (data) => {
-        output += data.toString();
+    try {
+      const response = await fetch('https://api.github.com/repos/hypnoglow/helm-s3/releases/latest');
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
       }
+      const data = await response.json();
+      return data.tag_name.replace(/^v/, '');
+    } catch (err) {
+      throw new Error(`Failed to fetch latest helm-s3 version: ${err.message}`);
     }
-  });
-
-  try {
-    const json = JSON.parse(output);
-    return json.tag_name.replace(/^v/, ''); // Remove "v" prefix if present
-  } catch (err) {
-    throw new Error(`Failed to fetch latest helm-s3 version: ${err.message}`);
   }
-}
 
 module.exports = { getLatestHelmS3Version };

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,24 @@
+const { exec } = require('@actions/exec');
+
+async function getLatestHelmS3Version() {
+  let output = '';
+  await exec('curl', [
+    '-s',
+    'https://api.github.com/repos/hypnoglow/helm-s3/releases/latest'
+  ], {
+    listeners: {
+      stdout: (data) => {
+        output += data.toString();
+      }
+    }
+  });
+
+  try {
+    const json = JSON.parse(output);
+    return json.tag_name.replace(/^v/, ''); // Remove "v" prefix if present
+  } catch (err) {
+    throw new Error(`Failed to fetch latest helm-s3 version: ${err.message}`);
+  }
+}
+
+module.exports = { getLatestHelmS3Version };


### PR DESCRIPTION
helm-s3 has had a recent change which has broken the builds. There is active work to fix this issue however this is not merged yet but previous versions work.

This PR enables passing the helmS3version as an optional parameter.

Please review and if it make sense merge.

- Added `helmS3Version` input to allow users to specify a Helm S3 plugin version.
- Defaults to the latest GitHub release if not provided.
- Updated `installPlugins` function to handle version installation.
- Updated `action.yml` to include `helmS3Version` as an optional parameter.
- Updated README to document the new input.